### PR TITLE
skip failing integration tests by default

### DIFF
--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -73,6 +73,10 @@ To run integration tests with an "emulated" OCM environment, run:
 OCM_ENV=integration make test/integration
 ```
 
+Note that some of the integration tests provided out of the box won't pass until the missing pieces of code are implemented.
+These tests are suppressed as not to cause test failures by default.
+See [main_test.go](../internal/dinosaur/test/main_test.go) for more information.
+
 To run integration tests with a real OCM environment, run:
 
 ```

--- a/internal/dinosaur/test/integration/admin_dinosaur_test.go
+++ b/internal/dinosaur/test/integration/admin_dinosaur_test.go
@@ -38,6 +38,8 @@ func NewAuthenticatedContextForAdminEndpoints(h *coreTest.Helper, realmRoles []s
 }
 
 func TestAdminDinosaur_Get(t *testing.T) {
+	skipTest(t)
+
 	sampleDinosaurID := api.NewID()
 	desiredDinosaurOperatorVersion := "test"
 	type args struct {

--- a/internal/dinosaur/test/integration/auth_test.go
+++ b/internal/dinosaur/test/integration/auth_test.go
@@ -105,6 +105,8 @@ func TestAuthFailure_withoutToken(t *testing.T) {
 }
 
 func TestAuthFailure_invalidTokenWithTypMissing(t *testing.T) {
+	skipTest(t)
+
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
 	defer ocmServer.Close()
 

--- a/internal/dinosaur/test/integration/data_plane_endpoints_test.go
+++ b/internal/dinosaur/test/integration/data_plane_endpoints_test.go
@@ -100,6 +100,8 @@ func setup(t *testing.T, claims claimsFunc, startupHook interface{}) TestServer 
 }
 
 func TestDataPlaneEndpoints_GetAndUpdateManagedDinosaurs(t *testing.T) {
+	skipTest(t)
+
 	testServer := setup(t, func(account *v1.Account, cid string, h *coreTest.Helper) jwt.MapClaims {
 		username, _ := account.GetUsername()
 		return jwt.MapClaims{

--- a/internal/dinosaur/test/integration/data_plane_endpoints_test.go
+++ b/internal/dinosaur/test/integration/data_plane_endpoints_test.go
@@ -44,10 +44,13 @@ type TestServer struct {
 	Ctx           context.Context
 }
 
+//nolint
 type claimsFunc func(account *v1.Account, clusterId string, h *coreTest.Helper) jwt.MapClaims
 
+//nolint
 var clusterId = api.NewID()
 
+//nolint
 func setup(t *testing.T, claims claimsFunc, startupHook interface{}) TestServer {
 
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
@@ -343,6 +346,7 @@ func TestDataPlaneEndpoints_GetAndUpdateManagedDinosaurs(t *testing.T) {
 	}
 }
 
+//nolint
 func findManagedDinosaurByID(slice []private.ManagedDinosaur, dinosaurId string) *private.ManagedDinosaur {
 	match := func(item private.ManagedDinosaur) bool { return item.Metadata.Annotations.MasId == dinosaurId }
 	for _, item := range slice {

--- a/internal/dinosaur/test/integration/dinosaurs_test.go
+++ b/internal/dinosaur/test/integration/dinosaurs_test.go
@@ -35,6 +35,8 @@ const (
 
 // TestDinosaurCreate_Success validates the happy path of the dinosaur post endpoint:
 func TestDinosaurCreate_Success(t *testing.T) {
+	skipTest(t)
+
 	// create a mock ocm api server, keep all endpoints as defaults
 	// see the mocks package for more information on the configurable mock server
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
@@ -148,6 +150,8 @@ func TestDinosaurCreate_TooManyDinosaurs(t *testing.T) {
 //
 // these could also be unit tests
 func TestDinosaurPost_Validations(t *testing.T) {
+	skipTest(t)
+
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
 	defer ocmServer.Close()
 
@@ -233,6 +237,8 @@ func TestDinosaurPost_Validations(t *testing.T) {
 
 // TestDinosaurPost_NameUniquenessValidations tests dinosaur cluster name uniqueness verification during its creation by the API
 func TestDinosaurPost_NameUniquenessValidations(t *testing.T) {
+	skipTest(t)
+
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
 	defer ocmServer.Close()
 
@@ -282,6 +288,8 @@ func TestDinosaurPost_NameUniquenessValidations(t *testing.T) {
 
 // TestDinosaurGet tests getting dinosaurs via the API endpoint
 func TestDinosaurGet(t *testing.T) {
+	skipTest(t)
+
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()
 	defer ocmServer.Close()
 
@@ -476,6 +484,8 @@ func TestDinosaur_Delete(t *testing.T) {
 
 // TestDinosaurList_Success tests getting dinosaur requests list
 func TestDinosaurList_Success(t *testing.T) {
+	skipTest(t)
+
 	// create a mock ocm api server, keep all endpoints as defaults
 	// see the mocks package for more information on the configurable mock server
 	ocmServer := mocks.NewMockConfigurableServerBuilder().Build()

--- a/internal/dinosaur/test/integration/main_test.go
+++ b/internal/dinosaur/test/integration/main_test.go
@@ -14,3 +14,9 @@ func TestMain(m *testing.M) {
 	glog.V(10).Infof("Starting integration test using go version %s", runtime.Version())
 	os.Exit(m.Run())
 }
+
+// skip integration tests that won't pass until the missing logic is implemented
+// https://bf2.zulipchat.com/#narrow/stream/315461-factorized-fleet-manager/topic/Integration.20tests
+func skipTest(t *testing.T) {
+	t.Skip("Implementation missing")
+}


### PR DESCRIPTION
## Description
Skip failing integration tests by default. This is useful as it enables integration tests to be used to identify regressions from day 1.

## Verification Steps
Run integration tests with "emulated" OCM, as described in docs/automated-testing.md The entire testsuite should pass.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Documentation added for the feature
- [ ] Code Review completed
- [ ] Verified independently by reviewer
- [ ] Equivalent Github Pull Request or an issue has been opened on the Quarkus based template   
